### PR TITLE
Typescript をインストール

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-astro": "0.27.2",
     "prettier": "2.8.8",
     "prettier-plugin-astro": "0.10.0",
+    "typescript": "5.1.6",
     "vercel": "31.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ devDependencies:
   prettier-plugin-astro:
     specifier: 0.10.0
     version: 0.10.0
+  typescript:
+    specifier: 5.1.6
+    version: 5.1.6
   vercel:
     specifier: 31.0.1
     version: 31.0.1(@types/node@14.18.33)


### PR DESCRIPTION
VSCode の Astro 拡張機能により自動的にグローバルインストールされている Typescript が利用されていたが、あまりよろしくないのでプロジェクト用にもインストールする。